### PR TITLE
Bump version 0.1.1 => 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,8 @@
 - `Updated` the `utils.email_check.EmailChecker` class for the new version of `aioredis`.
 - `Updated` the required dependencies.
 
-## 0.2.0[Upcoming]
+## 0.2.0
 - `Added` `send_mail`, `send_mass_mail` methods very similar to `Django` or `Flask-Mailman`.
-- `Added` more docstring for better understanding of all the apis.
-- `Fixed` several typos.
+- `Added` more docstrings for better understanding of all the apis.
+- `Added` few more test cases.
 - `Fixed` major bug at `MAIL_START_TLS`/`MAIL_START_SSL` configuration at `ConnectionConfig`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,14 +48,16 @@ class has following attributes
 
 
 -  recipients  : List of recipients.
--  attachments : attachments within mail
--  subject  : subject content of the mail
--  body : body of the message
--  cc : cc recipients of the mail
--  bcc : bcc recipients of the mail
--  reply_to : Reply-To recipients in the mail
--  charset : charset defaults to utf-8
--  subtype : subtype of the mail defaults to plain
+-  attachments : attachments within mail.
+-  subject  : subject content of the mail.
+-  body : body of the message.
+-  template_body: parameters for the jinja template.
+-  template_params: parameters for the jinja template.
+-  cc : cc recipients of the mail.
+-  bcc : bcc recipients of the mail.
+-  reply_to : Reply-To recipients in the mail.
+-  charset : charset defaults to utf-8.
+-  subtype : subtype of the mail defaults to plain.
 - add_recipient : a method to add additional recipients.
 - attach : a method to add additional attachments.
 

--- a/flask_mailing/mail.py
+++ b/flask_mailing/mail.py
@@ -124,8 +124,8 @@ class Mail(_MailMixin):
         """
         to send the message object.
 
-        :param message: The object of the Message pydantic class.
-        :param template_name: if you are about to render any template 
+        :param `message`: The object of the Message pydantic class.
+        :param `template_name`: if you are about to render any template 
         with the mail please provide the name of the template by using this param.
 
         ### For example => 
@@ -195,7 +195,6 @@ class Mail(_MailMixin):
             html=html_message,
             **msgkwargs
         )
-
         await self.send_message(message)
 
     async def send_mass_mail(
@@ -205,14 +204,13 @@ class Mail(_MailMixin):
         """
         To handle mass mailing.
 
-        :param datatuple: is a tuple in which each element is in this format:
+        :param `datatuple`: is a tuple in which each element is in this format:
         ```bash
         (subject, message, recipients)
         ```
         """
         for data in datatuple:
-            subject, message, recipients = data
-            await self.send_mail(subject, message, recipients)
+            await self.send_mail(*data)
 
 
 signals = blinker.Namespace()


### PR DESCRIPTION
- `Added` `send_mail`, `send_mass_mail` methods very similar to `Django` or `Flask-Mailman`.
- `Added` more docstrings for better understanding of all the apis.
- `Added` few more test cases.
- `Fixed` major bug at `MAIL_START_TLS`/`MAIL_START_SSL` configuration at `ConnectionConfig`.